### PR TITLE
Increase cart quantity

### DIFF
--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -13,6 +13,12 @@ class CartsController < ApplicationController
     redirect_back(fallback_location: root_path)
   end
 
+  def increase
+    item_id = params[:format]
+    @cart.increase_quantity_item(item_id)
+    redirect_to '/cart'
+  end
+
   def decrease
     item_id = params[:format]
     @cart.decrease_quantity_item(item_id)

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -19,6 +19,10 @@ class Cart
     end
   end
 
+  def increase_quantity_item(id)
+    contents[id.to_s] = (contents[id.to_s] || 0) + 1
+  end
+
   def count_of(id)
     contents[id.to_s].to_i
   end

--- a/app/views/carts/index.html.erb
+++ b/app/views/carts/index.html.erb
@@ -8,8 +8,9 @@
     <p>Price: $<%= item.price %></p>
     <p>Quantity: <%= quantity %></p>
     <p>Subtotal: $<%= quantity * item.price %></p>
-    <p><%= link_to "Decrease quantity", cart_path(item), action: :decrease, method: :put %>
-    <p><%= link_to "Remove", cart_path(item), method: :delete %></p>
+    <p><%= link_to "Decrease quantity", cart_path(item), action: :decrease, method: :put %></p>
+    <p><%= link_to "Increase quantity", cart_path(item), action: :increase, method: :patch %></p>
+    <p><%= link_to "Remove", cart_path(id: item.id), method: :delete %></p>
   </div>
   <div class="total">
     <% sum = 0 %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,11 +14,13 @@ Rails.application.routes.draw do
 
   resources :items, only: [:index, :show]
 
-  resources :carts, only: [:index, :create, :destroy]
+  resources :carts, only: [:index, :create]
+
+  patch '/cart', :to => 'carts#increase'
 
   put '/cart', :to => 'carts#decrease'
 
-  put '/cart', :to => 'carts#increase'
+  delete '/cart', :to => 'carts#destroy'
 
   get '/:category', to: 'categories#show', param: :slug, as: "category"
 

--- a/spec/features/visitor_can_decrease_item_quantity_from_cart_spec.rb
+++ b/spec/features/visitor_can_decrease_item_quantity_from_cart_spec.rb
@@ -6,10 +6,11 @@ require "rails_helper"
        it "visitor sees that she has 1 items in her cart and the subtotal of her order decreases" do
           create_items
           visit items_path
-          click_on "Add to cart"
-          click_on "Add to cart"
 
-          visit "/cart"
+          click_on "Add to cart"
+          click_on "Add to cart"
+          
+          visit carts_path
           expect(page).to have_content(2)
           expect(page).to have_content(39.98)
           expect(page).to have_content(@item.title)

--- a/spec/features/visitor_can_increase_item_quantity_in_cart_spec.rb
+++ b/spec/features/visitor_can_increase_item_quantity_in_cart_spec.rb
@@ -26,11 +26,3 @@ feature "Visitor can increase an item's quantity in the cart" do
     expect(@cart.total).to eq(39.98)
   end
 end
-
-# When I visit “/cart”
-# Then I should see my item with a quantity of 1
-# And when I increase the quantity
-# Then my current page should be ‘/cart’
-# And that item’s quantity should reflect the increase
-# And the subtotal for that item should increase
-# And the total for the cart should match that increase

--- a/spec/features/visitor_can_increase_item_quantity_in_cart_spec.rb
+++ b/spec/features/visitor_can_increase_item_quantity_in_cart_spec.rb
@@ -8,21 +8,21 @@ feature "Visitor can increase an item's quantity in the cart" do
   end
 
   scenario "visitor has an item in the cart and then she increases it to 2" do
-    visit '/cart'
+    visit items_path
 
+    click_on "Add to cart"
+
+    visit carts_path
     expect(page).to have_content(@item.title)
     expect(page).to have_content(1)
 
-    click_on "Increase"
+    click_on "Increase quantity"
 
     expect(current_path).to eq('/cart')
     expect(page).to have_content(@item.title)
+
     expect(page).to have_content(2)
-
-    expect(@cart.total_count).to eq(2)
-
-    expect(@cart.subtotal).to eq(39.98)
-
-    expect(@cart.total).to eq(39.98)
+    expect(page).to have_content(39.98)
+    expect(page).to have_content("Subtotal: $39.98")
   end
 end

--- a/spec/features/visitor_can_increase_item_quantity_in_cart_spec.rb
+++ b/spec/features/visitor_can_increase_item_quantity_in_cart_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+feature "Visitor can increase an item's quantity in the cart" do
+  before(:each) do
+
+    create_items
+
+  end
+
+  scenario "visitor has an item in the cart and then she increases it to 2" do
+    visit '/cart'
+
+    expect(page).to have_content(@item.title)
+    expect(page).to have_content(1)
+
+    click_on "Increase"
+
+    expect(current_path).to eq('/cart')
+    expect(page).to have_content(@item.title)
+    expect(page).to have_content(2)
+
+    expect(@cart.total_count).to eq(2)
+
+    expect(@cart.subtotal).to eq(39.98)
+
+    expect(@cart.total).to eq(39.98)
+  end
+end
+
+# When I visit “/cart”
+# Then I should see my item with a quantity of 1
+# And when I increase the quantity
+# Then my current page should be ‘/cart’
+# And that item’s quantity should reflect the increase
+# And the subtotal for that item should increase
+# And the total for the cart should match that increase

--- a/spec/features/visitor_can_remove_item_from_cart_spec.rb
+++ b/spec/features/visitor_can_remove_item_from_cart_spec.rb
@@ -1,19 +1,26 @@
-require "rails_helper"
+require 'rails_helper'
 
- describe "Visitor cart has an item in it" do
-   describe "visitor sees that her cart has a quantity of 1" do
-     describe "the visitor can remove the item" do
-       it "visitor sees that she has 0 items in her cart and the subtotal of her order decreases" do
-         @item = create_items
-          visit "/cart"
-          expect(page).to have_content(1)
-          expect(page).to have_content(19.99)
-          expect(page).to have_content(@item.title)
-          click_on "decrease quantity"
-          expect(page).to_not have_content(19.99)
-          expect(page).to_not have_content(@item.title)
-          expect(page).to have_content("Subtotal (0 items) is $0")
-       end
-     end
-   end
- end
+RSpec.feature "Removing an item from my cart" do
+  before(:each) do
+    create_items
+
+    visit items_path
+  end
+  describe "When a visitor is viewing their cart" do
+    it "they can remove an item" do
+      click_on "Add to cart"
+
+      click_on "Add to cart"
+
+      click_on "Cart"
+
+      expect(page).to have_link("Remove")
+
+      click_link("Remove")
+
+      expect(current_path).to eq(carts_path)
+      expect(page).to have_content("Successfully removed #{@item.title} from your cart.")
+      expect(page).to have_link(@item.title, item_path(@item))
+    end
+  end
+end


### PR DESCRIPTION
#8 #14 

Description of Changes Made:
 Refactor increase items quantity in cart test, add increase action to carts controller, add route as patch pointing to a carts#increase, add cart method to increase quantity. 

Anticipated Code Effects: 
(Would this merge affect any other piece of our code?)
This could affect any added route to /cart. We need to be able to namespace or slug /carts and /cart. We currently are using patch and put /cart, so we would not have a steadily available method to edit the page. Another thing to consider is if our decrease method is actually removing an item whose quantity drops down to 0. 

Also is there a way that we can pass a specific string into the params/session so that we can then use it in a conditional within an update action (living in the carts controller). That way we can have one action for both the decrease and increase methods. 


Reviewer: 
@mimilettd - primary

@samuelssnider @JunePaloma 